### PR TITLE
Added brightnucleus/options-store as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   "require": {
     "brightnucleus/values": "^0.2.0",
     "brightnucleus/exceptions": "^0.3.0",
+    "brightnucleus/options-store": "^0.1.0",
     "brightnucleus/validation": "^0.1.0"
   },
   "autoload": {


### PR DESCRIPTION
`brightnucleus/options-store` is required but not listed in `composer.json`.